### PR TITLE
FIX newer dependencies and add search properties

### DIFF
--- a/jstree.js
+++ b/jstree.js
@@ -21,7 +21,7 @@ Template.afJsTree.rendered = function () {
     var $tree = $(this.firstNode);
     var data = self.data;
     var nodes = data.atts.nodes;
-    
+
     selectnodes = function (node) {
         node.forEach(function(d) {
             if (_.contains(self.value.get(), d.id)) {
@@ -34,10 +34,11 @@ Template.afJsTree.rendered = function () {
         return node
     }
     nodes = selectnodes(nodes);
-    
+
     this.autorun(function () {
         $tree.jstree({
             plugins: options.plugins || [],
+            search: options.search || [],
             core: {
                 themes: options.themes || {},
                 data: function (node, cb) {

--- a/package.js
+++ b/package.js
@@ -1,5 +1,5 @@
 Package.describe({
-  name: 'dguedry:autoform-jstree',
+  name: 'artjomg:autoform-jstree',
   version: '0.0.1',
   // Brief, one-line summary of the package.
   summary: 'jsTree input for Autoform',
@@ -11,10 +11,10 @@ Package.describe({
 });
 
 Package.onUse(function(api) {
-  api.use('templating@1.0.0');
-  api.use('blaze@2.0.0');
-  api.use('aldeed:template-extension@3.4.3');
-  api.use('aldeed:autoform@4.0.0 || 5.0.0');
+  api.use('templating@1.3.0');
+  api.use('blaze@2.3.0');
+  api.use('aldeed:template-extension@4.0.0');
+  api.use('aldeed:autoform@4.0.0 || 5.0.0 || 5.8.1');
   api.addFiles([
     'jstree.html',
     'jstree.js'


### PR DESCRIPTION
Hi this allows to add search properties to a jStree view as explained here: https://www.jstree.com/api/#/?f=$.jstree.defaults.search


If you merge this I noticed that this commit changed the plugin name for my local development. Please fix this in case of pull.

**Template**
`
                    <input id="typessearch" type="text" placeholder="search">
                    {{>afFormGroup name="my selection"}}
`

**Template Helper**

> 'keypress #typessearch': function (evt) {
>       var value = evt.currentTarget.value;
>       console.log(value);
>       $("div[name='myselection']").jstree(true).search(value);
>   },
> 
>   'keydown #typessearch': function (evt) {
>       var value = evt.currentTarget.value;
>       console.log(value);
>       if (evt.keyCode==8 && value.length <=1){
>         $("div[name='myselection']").jstree(true).clear_search();
>       }
>   }